### PR TITLE
No indentation from header to text

### DIFF
--- a/src/components/categoryPage/pageTitle/PageTitle.module.css
+++ b/src/components/categoryPage/pageTitle/PageTitle.module.css
@@ -19,7 +19,7 @@
 }
 
 .description {
-  width: 64%;
+  width: 65%;
   text-align: center;
 
   font-weight: 500;
@@ -34,11 +34,10 @@
 
 @media (max-width: 1023px) {
   .title {
-    font-size: 18px;
+    font-size: 24px;
   }
 
   .description {
-    font-size: 12px;
-    width: 96%;
+    width: 100%;
   }
 }

--- a/src/components/categoryPage/productState/ProductsState.module.css
+++ b/src/components/categoryPage/productState/ProductsState.module.css
@@ -1,0 +1,9 @@
+.section {
+  padding: 80px 0 32px;
+}
+
+@media (max-width: 1023px) {
+  .section {
+    padding: 40px 0 24px;
+  }
+}

--- a/src/components/categoryPage/productState/ProductsState.tsx
+++ b/src/components/categoryPage/productState/ProductsState.tsx
@@ -2,7 +2,7 @@ import PageTitle from 'src/components/categoryPage/pageTitle';
 
 import { Language } from 'src/types/language';
 
-import st from 'src/components/homePage/productsSection/ProductsSection.module.css';
+import st from 'src/components/categoryPage/productState/ProductsState.module.css';
 
 type ProductsStateProps = {
   language: Language;


### PR DESCRIPTION
Style fixes implemented:
- indentation on Shop page for main title/description
- updating font size for title and description in accordance with [design](https://www.figma.com/design/juPIKygxIAgNaBz6kQjj0M/BoarLabs---Kavoon?node-id=4020-25294&t=ulhoDvcwva80utvI-1) in Figma
- updating width for description for better UX for multi languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new responsive design for the `ProductsState` component, enhancing layout adaptability across different screen sizes.
  
- **Style**
	- Updated styles for the `PageTitle` component, improving typography and layout for better visual presentation.
	- Added new padding styles for the `.section` class in the `ProductsState` component to improve responsiveness.

- **Chores**
	- Updated the import path for the CSS module in the `ProductsState` component to reflect the new styling location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->