### PR TITLE
112 The message from the “Support” window is not sent to the selected messenger

### DIFF
--- a/src/components/common/chat/PopupContent.tsx
+++ b/src/components/common/chat/PopupContent.tsx
@@ -46,8 +46,7 @@ function PopupContent({ language }: Props) {
 
   return (
     <div className={st.wrapper}>
-      <Spinner loading={isLoading} />
-      {!isLoading && renderComponent()}
+      {isLoading ? <Spinner loading={true} /> : renderComponent()}
     </div>
   );
 }

--- a/src/components/common/contactsMessengerPicker/ContactsMessengerPicker.tsx
+++ b/src/components/common/contactsMessengerPicker/ContactsMessengerPicker.tsx
@@ -36,9 +36,11 @@ function ContactsMessengerPicker({
     setOpened(false);
   });
   const handleSelect = (item) => {
-    setOpened(false);
     setPickedItem(item);
     onMessengerChange(item.name);
+    setTimeout(() => {
+      setOpened(false);
+    }, 50);
   };
 
   let statusWrapperClassName = isOpened


### PR DESCRIPTION
Fixed a bug with the contact messenger closing when choosing a messenger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user experience in the `ContactsMessengerPicker` by adding a brief delay before closing the dropdown after an item selection, allowing for visual confirmation.
  
- **Bug Fixes**
	- Improved rendering logic in the `PopupContent` component to ensure the loading spinner displays correctly based on the loading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->