### PR TITLE
114 Missing text box “Write a message” in the “Support” window (on mobile in the Safari web browser) bug

### DIFF
--- a/src/components/common/chat/Popup.module.css
+++ b/src/components/common/chat/Popup.module.css
@@ -64,7 +64,7 @@
 @media (max-width: 480px) {
   .wrapper {
     width: 100%;
-    height: calc(100vh - 80px);
+    height: calc(100% - 80px);
     top: 80px;
     left: 0;
     border-radius: 0;


### PR DESCRIPTION
Fixed a bug with the support window on the mobile version, where the bottom bar in Safari covered the support window.