### PR TITLE
Configure workflow to run on pull requests

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,7 +1,11 @@
 name: Vercel Preview Deployment
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -12,6 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: ${{ github.ref != 'ref/heads/main' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +36,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: ${{ github.ref != 'ref/heads/main' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,6 +56,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: ${{ github.ref != 'ref/heads/main' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -69,6 +76,7 @@ jobs:
   preview-deployment:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: ${{ github.ref != 'ref/heads/main' }}
     environment:
       name: preview
       url: ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -16,7 +16,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.ref != 'ref/heads/main' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,7 +35,6 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.ref != 'ref/heads/main' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,7 +54,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.ref != 'ref/heads/main' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -76,7 +73,6 @@ jobs:
   preview-deployment:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.ref != 'ref/heads/main' }}
     environment:
       name: preview
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Vercel preview deployments. Key changes include:

1. Trigger Update: The workflow now triggers on `pull_request` events (opened, synchronize, reopened), replacing the previous `workflow_dispatch` trigger.
   
These changes ensure the preview deployment workflow is triggered for pull requests and doesn't run on the `main` branch.