### PR TITLE
Style fix for Write a review modal window

### DIFF
--- a/src/components/common/modalWindow/ModalWindow.module.css
+++ b/src/components/common/modalWindow/ModalWindow.module.css
@@ -18,6 +18,10 @@
   background-color: var(--white);
   color: var(--main-text-color);
   width: fit-content;
+
+  & [class^='loading_wrapper'] {
+    height: auto;
+  }
 }
 
 .closeButton {


### PR DESCRIPTION
- used a custom height for loading inside the “Write a review” modal window to avoid stretching the height

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced styling for loading elements within the modal, allowing for automatic height adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->