### PR TITLE
Create robots.txt for Kavoon website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - Unreleased
 
+### Added
+- robots.txt for search engine crawlers ([200](https://github.com/boarlabsxyz/Kavoon/pull/200))
+- google html file for verification website's ownership ([199](https://github.com/boarlabsxyz/Kavoon/pull/199))
+
 ### Fixed
 - making and updating snapshots in e2e-tests on github actions ([#181](https://github.com/boarlabsxyz/Kavoon/pull/181))
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/status-reviews',
+    },
+  };
+}


### PR DESCRIPTION
- generating the robots.ts file according to the [Next.js docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots#generate-a-robots-file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `robots.txt` file for search engine crawlers, specifying access rules that allow indexing of most pages while restricting access to the `/status-reviews` path.
  - Added a Google HTML file for website ownership verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->