### PR TITLE
Disable sonarqube for production push

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,7 +129,7 @@ jobs:
 
   sonarqube:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main' }}
     needs: unit-tests
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- adding condition to skip sonarqube if production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined our automated quality scanning criteria to run only when necessary, ensuring a more efficient development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->