### PR TITLE
Disable sonarqube for production push

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,7 +129,7 @@ jobs:
 
   sonarqube:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main' }}
     needs: unit-tests
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -131,6 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main' }}
     needs: unit-tests
+    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- adding `continue-on-error: true` to sonarqube to execute before deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined internal automation processes for more reliable operations.
	- Enhanced error handling to ensure continuous workflow even if issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->