### PR TITLE
Disable sonarqube for production push

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,7 +129,7 @@ jobs:
 
   sonarqube:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs: unit-tests
     continue-on-error: true
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,7 +129,7 @@ jobs:
 
   sonarqube:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main' }}
     needs: unit-tests
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -131,6 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main' }}
     needs: unit-tests
+    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- removing condition for `refs/heads/main` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the deployment pipeline's error handling by allowing subsequent steps to execute even if early quality checks encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->